### PR TITLE
Fix workflow YAML break + clean stale monolith refs (Keeper ruling 20… (Keeper to merge)

### DIFF
--- a/.github/workflows/garden_codex_maintenance.yml
+++ b/.github/workflows/garden_codex_maintenance.yml
@@ -247,12 +247,8 @@ jobs:
                   f"ACACIA · GARDEN · CODEX · MONOLITH · CHUNK {chunk_idx:03}",
                   "\n".join(current_sections)
               )
-              # Disabled 2026-08-06 per Keeper ruling (Archive retirement): stopped writing
-              # physical chunk_path files; chunk_files list is still populated below so the
-              # Garden API index (section 4) keeps working. See PR "Archive retirement
-              # (Keeper to merge)" on witness/archive-retirement-2026-08.
-              print(f"[MONOLITH] Wrote chunk {chunk_idx:03} → {chunk_path}")
-              chunk_files.append((chunk_name, [str(p) for p in current_paths]))
+              # Disabled 2026-08-06 per Keeper ruling (Archive retirement): stopped writing physical chunk_path files. Updated 2026-08-07 (workflow-fix): chunk_files is no longer populated either, since section 4 (Garden API index) no longer references it. See PR "Workflow fix (Keeper to merge)" on witness/workflow-fix-2026-08-07.
+              print(f"[MONOLITH] Skipped chunk {chunk_idx:03} (disabled 2026-08-06)")
               chunk_idx += 1
               current_sections = []
               current_paths = []
@@ -302,22 +298,15 @@ jobs:
           index_sections.append(f"<p>Total files included: {total_files}</p>")
           index_sections.append("<p>See also: <code>docs/Archives/GARDEN_MANIFEST.json</code> and <code>docs/api/GARDEN_API_INDEX.json</code>.</p>")
 
-# Disabled 2026-08-06 per Keeper ruling (Archive retirement): stopped writing
-# docs/Archives/CODEX_MONOLITH.html (the chunk index page). See PR "Archive
-# retirement (Keeper to merge)" on witness/archive-retirement-2026-08.
+          # Disabled 2026-08-06 per Keeper ruling (Archive retirement): stopped writing
+          # docs/Archives/CODEX_MONOLITH.html (the chunk index page). See PR "Archive
+          # retirement (Keeper to merge)" on witness/archive-retirement-2026-08.
           # ---------- 4) Garden API index ----------
 
           api_index = {
               "manifest": "docs/Archives/GARDEN_MANIFEST.json",
-              "monolith_index": "docs/Archives/CODEX_MONOLITH.html",
-              "monolith_chunks": [
-                  {
-                      "file": chunk_name,
-                      "paths": paths
-                  }
-                  for chunk_name, paths in chunk_files
-              ]
-          }
+              # Disabled 2026-08-07 per Keeper ruling (workflow-fix): removed stale "monolith_index"/"monolith_chunks" keys, which pointed at deleted/phantom monolith files; see PR "Workflow fix (Keeper to merge)" on witness/workflow-fix-2026-08-07.
+                        }
 
           API_INDEX_JSON.write_text(
               json.dumps(api_index, indent=2, ensure_ascii=False),


### PR DESCRIPTION
Do not merge — Keeper merges by own hand.

…26-08-07)


Corrects an indentation bug introduced by the archive-retirement commit that terminated the run: | block scalar early, breaking the entire garden_codex_maintenance.yml workflow (both the archive-retirement branch push and the merge to main failed with "Invalid workflow file" at line 311). Also removes the stale "monolith_index"/"monolith_chunks" keys from the Garden API index (section 4), which pointed at deleted/phantom monolith files, and stops populating the now-unused chunk_files list.